### PR TITLE
Add KDE Neon 5.9

### DIFF
--- a/kdeneon/kdeneon-5.9.txt
+++ b/kdeneon/kdeneon-5.9.txt
@@ -1,0 +1,11 @@
+NAME="KDE neon"
+VERSION="5.9"
+ID=neon
+ID_LIKE="ubuntu debian"
+PRETTY_NAME="KDE neon User Edition 5.9"
+VERSION_ID="16.04"
+HOME_URL="http://neon.kde.org/"
+SUPPORT_URL="http://neon.kde.org/"
+BUG_REPORT_URL="http://bugs.kde.org/"
+VERSION_CODENAME=xenial
+UBUNTU_CODENAME=xenial


### PR DESCRIPTION
Adding for completeness, but KDE Neon 5.9 has snapd installed by default and snaps work out of the box. \o/